### PR TITLE
DM-29314: Add debiased PSF moments to HSM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/testshape
 tests/.tests
 ups/*.cfgc
 python/lsst/meas/extensions/shapeHSM/version.py
+.vscode

--- a/include/lsst/meas/extensions/shapeHSM/HsmAdapter.h
+++ b/include/lsst/meas/extensions/shapeHSM/HsmAdapter.h
@@ -19,9 +19,9 @@ public:
     /// doesn't allow us to access a shared_ptr to the pixels.  Instead, we use a
     /// dummy shared ptr to a single (new) pixel.  The ImageConverter is holding
     /// on to this too (RAII) so we shouldn't have any memory worries.
-    ImageConverter(PTR(afw::image::Image<PixelT>) image, geom::Box2I box) :
+    ImageConverter(std::shared_ptr<afw::image::Image<PixelT>> image, geom::Box2I box) :
         _image(image), _owner(new PixelT), _box(box) {}
-    ImageConverter(PTR(afw::image::Image<PixelT>) image) :
+    ImageConverter(std::shared_ptr<afw::image::Image<PixelT>> image) :
         _image(image), _owner(new PixelT), _box(image->getBBox(afw::image::LOCAL)) {}
 
     /// Conversion
@@ -61,7 +61,7 @@ public:
 #endif
 
 private:
-    PTR(afw::image::Image<PixelT>) _image;
+    std::shared_ptr<afw::image::Image<PixelT>> _image;
     std::shared_ptr<PixelT> _owner;
     geom::Box2I _box;
 };
@@ -71,7 +71,7 @@ private:
 ///
 /// HSM uses a mask where 0 = bad, 1 = good.
 inline
-PTR(afw::image::Image<int>) convertMask(
+std::shared_ptr<afw::image::Image<int>> convertMask(
     afw::image::Mask<afw::image::MaskPixel> const& afwMask, ///< Traditional afw Mask using mask planes
     geom::Box2I const& bbox,            ///< Bounding box of interest
     afw::image::MaskPixel const badPixelMask ///< Mask for selecting bad pixels
@@ -79,7 +79,7 @@ PTR(afw::image::Image<int>) convertMask(
 {
     typedef afw::image::Image<int> ImageI;
     typedef afw::image::Mask<afw::image::MaskPixel> Mask;
-    PTR(ImageI) hsmMask = std::make_shared<ImageI>(bbox);
+    std::shared_ptr<ImageI> hsmMask = std::make_shared<ImageI>(bbox);
     for (int y = bbox.getMinY(); y <bbox.getMaxY(); ++y) {
         Mask::const_x_iterator in = afwMask.x_at(bbox.getMinX() - afwMask.getX0(), y - afwMask.getY0());
         ImageI::x_iterator out = hsmMask->row_begin(y - hsmMask->getY0());

--- a/include/lsst/meas/extensions/shapeHSM/HsmMomentsControl.h
+++ b/include/lsst/meas/extensions/shapeHSM/HsmMomentsControl.h
@@ -107,8 +107,8 @@ protected:
     template<typename PixelT>
     void calculate(
         afw::table::SourceRecord& source, // Source for recording moments
-        PTR(afw::image::Image<PixelT>) const& afwImage, // Image on which to measure moments
-        PTR(afw::image::Mask<afw::image::MaskPixel>) const& afwMask, // Mask for image
+        std::shared_ptr<afw::image::Image<PixelT>> const& afwImage, // Image on which to measure moments
+        std::shared_ptr<afw::image::Mask<afw::image::MaskPixel>> const& afwMask, // Mask for image
         geom::Box2I const& bbox,     // Bounding box
         geom::Point2D const& center, // Starting center for measuring moments
         afw::image::MaskPixel const badPixelMask, // Bitmask for bad pixels

--- a/include/lsst/meas/extensions/shapeHSM/HsmShapeControl.h
+++ b/include/lsst/meas/extensions/shapeHSM/HsmShapeControl.h
@@ -93,7 +93,7 @@ public:
 };
 
 /*
- * @brief A measurement algorithm for measuring HSM shape 
+ * @brief A measurement algorithm for measuring HSM shape
  * HSM shape algorithm class - we use one class for all algorithms; all the specialized
  * work is done by the control class _makeAlgorithm implementations.
  *

--- a/python/lsst/meas/extensions/shapeHSM/__init__.py
+++ b/python/lsst/meas/extensions/shapeHSM/__init__.py
@@ -43,3 +43,5 @@ wrapSimpleAlgorithm(HsmSourceMomentsAlgorithm, name="ext_shapeHSM_HsmSourceMomen
                     Control=HsmSourceMomentsRoundControl, executionOrder=BasePlugin.SHAPE_ORDER)
 wrapSimpleAlgorithm(HsmPsfMomentsAlgorithm, name="ext_shapeHSM_HsmPsfMoments",
                     Control=HsmPsfMomentsControl, executionOrder=BasePlugin.SHAPE_ORDER)
+wrapSimpleAlgorithm(HsmPsfMomentsDebiasedAlgorithm, name="ext_shapeHSM_HsmPsfMomentsDebiased",
+                    Control=HsmPsfMomentsDebiasedControl, executionOrder=BasePlugin.FLUX_ORDER+1)

--- a/python/lsst/meas/extensions/shapeHSM/hsmMomentsControl.cc
+++ b/python/lsst/meas/extensions/shapeHSM/hsmMomentsControl.cc
@@ -20,6 +20,7 @@
  * see <https://www.lsstcorp.org/LegalNotices/>.
  */
 #include "pybind11/pybind11.h"
+#include "pybind11/stl.h"
 
 #include "lsst/meas/extensions/shapeHSM/HsmMomentsControl.h"
 #include "lsst/pex/config/python.h"
@@ -48,7 +49,14 @@ PYBIND11_MODULE(hsmMomentsControl, mod) {
 
     py::class_<HsmPsfMomentsAlgorithm, std::shared_ptr<HsmPsfMomentsAlgorithm>, HsmMomentsAlgorithm>
             clsHsmPsfMomentsAlgorithm(mod, "HsmPsfMomentsAlgorithm");
-    py::class_<HsmPsfMomentsControl> clsHsmPsfMomentsControl(mod, "HsmPsfMomentsControl");
+    py::class_<HsmPsfMomentsControl, std::shared_ptr<HsmPsfMomentsControl>>
+            clsHsmPsfMomentsControl(mod, "HsmPsfMomentsControl");
+
+    py::class_<HsmPsfMomentsDebiasedAlgorithm, std::shared_ptr<HsmPsfMomentsDebiasedAlgorithm>,
+               HsmPsfMomentsAlgorithm, HsmMomentsAlgorithm>
+            clsHsmPsfMomentsDebiasedAlgorithm(mod, "HsmPsfMomentsDebiasedAlgorithm");
+    py::class_<HsmPsfMomentsDebiasedControl, std::shared_ptr<HsmPsfMomentsDebiasedControl>>
+            clsHsmPsfMomentsDebiasedControl(mod, "HsmPsfMomentsDebiasedControl");
 
     /* Constructors */
     clsHsmSourceMomentsAlgorithm.def(
@@ -62,10 +70,25 @@ PYBIND11_MODULE(hsmMomentsControl, mod) {
             "ctrl"_a, "name"_a, "schema"_a);
     clsHsmPsfMomentsControl.def(py::init<>());
 
+    clsHsmPsfMomentsDebiasedAlgorithm.def(
+            py::init<HsmPsfMomentsDebiasedAlgorithm::Control const &,
+                     std::string const &,
+                     afw::table::Schema &>(),
+            "ctrl"_a, "name"_a, "schema"_a);
+    clsHsmPsfMomentsDebiasedControl.def(py::init<>());
+
     /* Members */
     LSST_DECLARE_CONTROL_FIELD(clsHsmSourceMomentsControl, HsmSourceMomentsControl, badMaskPlanes);
     LSST_DECLARE_CONTROL_FIELD(clsHsmSourceMomentsControl, HsmSourceMomentsControl, roundMoments);
     LSST_DECLARE_CONTROL_FIELD(clsHsmSourceMomentsControl, HsmSourceMomentsControl, addFlux);
+
+    LSST_DECLARE_CONTROL_FIELD(clsHsmPsfMomentsControl, HsmPsfMomentsControl, useSourceCentroidOffset);
+
+    LSST_DECLARE_CONTROL_FIELD(
+            clsHsmPsfMomentsDebiasedControl, HsmPsfMomentsDebiasedControl, useSourceCentroidOffset);
+    LSST_DECLARE_CONTROL_FIELD(clsHsmPsfMomentsDebiasedControl, HsmPsfMomentsDebiasedControl, noiseSource);
+    LSST_DECLARE_CONTROL_FIELD(clsHsmPsfMomentsDebiasedControl, HsmPsfMomentsDebiasedControl, seedOffset);
+    LSST_DECLARE_CONTROL_FIELD(clsHsmPsfMomentsDebiasedControl, HsmPsfMomentsDebiasedControl, badMaskPlanes);
 
     clsHsmMomentsAlgorithm.def("fail", &HsmMomentsAlgorithm::fail);
 }

--- a/src/HsmMoments.cc
+++ b/src/HsmMoments.cc
@@ -27,6 +27,7 @@
 #include "lsst/afw/math/Statistics.h"
 #include "lsst/afw/table/Source.h"
 #include "lsst/afw/geom/ellipses.h"
+#include "lsst/afw/math/Random.h"
 
 #include "galsim/Image.h"
 #include "galsim/hsm/PSFCorr.h"
@@ -44,7 +45,8 @@ base::FlagDefinition const HsmMomentsAlgorithm::FAILURE = flagDefinitions.addFai
 base::FlagDefinition const HsmMomentsAlgorithm::NO_PIXELS = flagDefinitions.add("flag_no_pixels", "no pixels to measure");
 base::FlagDefinition const HsmMomentsAlgorithm::NOT_CONTAINED = flagDefinitions.add("flag_not_contained", "center not contained in footprint bounding box");
 base::FlagDefinition const HsmMomentsAlgorithm::PARENT_SOURCE = flagDefinitions.add("flag_parent_source", "parent source, ignored");
-base::FlagDefinition const HsmMomentsAlgorithm::GALSIM("flag_galsim", "GalSim failure");
+base::FlagDefinition const HsmMomentsAlgorithm::GALSIM = flagDefinitions.add("flag_galsim", "GalSim failure");
+base::FlagDefinition const HsmPsfMomentsDebiasedAlgorithm::EDGE = flagDefinitions.add("flag_edge", "Variance undefined outside image edge");
 
 base::FlagDefinitionList const & HsmMomentsAlgorithm::getFlagDefinitions() {
     return flagDefinitions;
@@ -60,7 +62,8 @@ void HsmMomentsAlgorithm::calculate(
     afw::image::MaskPixel const badPixelMask,
     float const width,
     bool roundMoments,
-    bool addFlux
+    bool addFlux,
+    bool subtractCenter
 ) const {
     ImageConverter<PixelT> const image(afwImage, bbox);
     std::shared_ptr<afw::image::Image<int>> hsmMask = convertMask(*afwMask, bbox, badPixelMask);
@@ -85,6 +88,10 @@ void HsmMomentsAlgorithm::calculate(
     base::CentroidResult centroidResult;
     centroidResult.x = shape.moments_centroid.x;
     centroidResult.y = shape.moments_centroid.y;
+    if (subtractCenter) {
+        centroidResult.x -= center.getX();
+        centroidResult.y -= center.getY();
+    }
     source.set(_centroidResultKey, centroidResult);
     base::ShapeResult shapeResult;
     shapeResult.setShape(Ellipse(ellip, radius));
@@ -137,24 +144,154 @@ void HsmSourceMomentsAlgorithm::measure(
                                    _ctrl.addFlux);
 }
 
+
+// PsfMomentsAlgorithm
+
+
 void HsmPsfMomentsAlgorithm::measure(
     afw::table::SourceRecord & source,
     afw::image::Exposure<float> const & exposure
 ) const {
-
     geom::Point2D center = _centroidExtractor(source, _flagHandler);
 
-    typedef afw::image::Mask<afw::image::MaskPixel> Mask;
-    std::shared_ptr<afw::detection::Psf::Image> image = exposure.getPsf()->computeKernelImage(center);
+    auto psfImage = getPsfImage(center, source, exposure);
+    auto psfMask = getPsfMask(center, source, exposure);
+    auto badPixelMask = getBadPixelMask(exposure);
 
-    // Create a dummy mask
-    std::shared_ptr<Mask> mask = std::make_shared<Mask>(image->getDimensions());
+    double const sigmaGuess = exposure.getPsf()->computeShape(center).getTraceRadius();
+    const geom::Point2D centroidGuess = (
+        _ctrl->useSourceCentroidOffset ?
+        center :
+        geom::Point2D(std::floor(center.getX()+0.5), std::floor(center.getY()+0.5))
+    );
+
+    bool roundMoments = false;
+    bool addFlux = false;
+    bool subtractCenter = true;
+    HsmMomentsAlgorithm::calculate(
+        source, psfImage, psfMask, psfImage->getBBox(afw::image::PARENT),
+        centroidGuess, badPixelMask, sigmaGuess, roundMoments, addFlux, subtractCenter
+    );
+}
+
+std::shared_ptr<afw::detection::Psf::Image> HsmPsfMomentsAlgorithm::getPsfImage(
+    geom::Point2D center,
+    afw::table::SourceRecord & source,
+    afw::image::Exposure<float> const & exposure
+) const {
+    if (_ctrl->useSourceCentroidOffset) {
+        return exposure.getPsf()->computeImage(center);
+    } else {
+        auto psfImage = exposure.getPsf()->computeKernelImage(center);
+        psfImage->setXY0(
+            psfImage->getX0() + std::floor(center.getX() + 0.5),
+            psfImage->getY0() + std::floor(center.getY() + 0.5)
+        );
+        return psfImage;
+    }
+}
+
+std::shared_ptr<afw::image::Mask<afw::image::MaskPixel>> HsmPsfMomentsAlgorithm::getPsfMask(
+    geom::Point2D center,
+    afw::table::SourceRecord & source,
+    afw::image::Exposure<float> const & exposure
+) const {
+    auto psf = exposure.getPsf();
+    auto bbox = psf->computeBBox();
+
+    // Add floor(center+0.5) to bbox to make it look like psf->computeImage()->getBBox()
+    auto shift = geom::Extent2I(std::floor(center.getX()+0.5), std::floor(center.getY()+0.5));
+    bbox.shift(shift);
+
+    auto mask = std::make_shared<afw::image::Mask<afw::image::MaskPixel>>(bbox);
     *mask = 0;
-    mask->setXY0(image->getXY0());
+    return mask;
+}
 
-    double const psfSigma = exposure.getPsf()->computeShape(center).getTraceRadius();
-    HsmMomentsAlgorithm::calculate(source, image, mask, image->getBBox(afw::image::PARENT),
-                                   geom::Point2D(0, 0), 0, psfSigma);
+
+// PsfMomentsDebiasedAlgorithm
+
+
+std::shared_ptr<afw::detection::Psf::Image> HsmPsfMomentsDebiasedAlgorithm::getPsfImage(
+    geom::Point2D center,
+    afw::table::SourceRecord & source,
+    afw::image::Exposure<float> const & exposure
+) const {
+
+    using PsfPixel = afw::detection::Psf::Pixel;
+
+    auto thisCtrl = std::static_pointer_cast<Control::element_type>(_ctrl);
+
+    auto psfImage = HsmPsfMomentsAlgorithm::getPsfImage(center, source, exposure);
+
+    // Psf image crossing exposure edge is fine if we're getting the variance from metadata,
+    // but not okay if we're getting the variance from the variance plane.  In both cases,
+    // set the EDGE flag, but only fail hard if using variance plane.
+    auto overlap = psfImage->getBBox();
+    overlap.clip(exposure.getBBox());
+    if (overlap != psfImage->getBBox()) {
+        _flagHandler.setValue(source, EDGE.number, true);
+        if (thisCtrl->noiseSource == "variance") {
+            _flagHandler.setValue(source, FAILURE.number, true);
+            throw LSST_EXCEPT(
+                base::MeasurementError,
+                "Variance undefined outside image bounds",
+                EDGE.number
+            );
+        }
+    }
+
+    // match Psf flux to source
+    auto flux = source.getPsfInstFlux();
+    (*psfImage) *= flux;
+
+    // Add Gaussian noise to image
+    afw::image::Image<PsfPixel> noise(psfImage->getBBox());
+    afw::math::Random rand(afw::math::Random::MT19937, source.getId() + thisCtrl->seedOffset);
+    afw::math::randomGaussianImage<afw::image::Image<PsfPixel>>(&noise, rand);
+    if (thisCtrl->noiseSource == "meta") {
+        double bgmean;
+        try {
+            bgmean = exposure.getMetadata()->getAsDouble("BGMEAN");
+        } catch (pex::exceptions::NotFoundError& e) {
+            throw LSST_EXCEPT(base::FatalAlgorithmError, e.what());
+        }
+        noise *= std::sqrt(bgmean);
+    } else if (thisCtrl->noiseSource == "variance") {
+        afw::image::Image<float> var(
+            *exposure.getMaskedImage().getVariance(),
+            psfImage->getBBox(),
+            afw::image::PARENT,
+            true
+        );
+        var.sqrt();
+        noise *= var;
+    }
+    (*psfImage) += noise;
+
+    return psfImage;
+}
+
+std::shared_ptr<afw::image::Mask<afw::image::MaskPixel>> HsmPsfMomentsDebiasedAlgorithm::getPsfMask(
+    geom::Point2D center,
+    afw::table::SourceRecord & source,
+    afw::image::Exposure<float> const & exposure
+) const {
+    // Copy part of exposure mask that overlaps psf bbox.
+    // Assume rest of PSF is unmasked.
+    auto psfMask = HsmPsfMomentsAlgorithm::getPsfMask(center, source, exposure);
+    auto overlap = psfMask->getBBox();
+    overlap.clip(exposure.getBBox());
+    (*psfMask)[overlap] = (*exposure.getMaskedImage().getMask())[overlap];
+    return psfMask;
+}
+
+afw::image::MaskPixel const HsmPsfMomentsDebiasedAlgorithm::getBadPixelMask(
+    afw::image::Exposure<float> const & exposure
+) const {
+    return exposure.getMaskedImage().getMask()->getPlaneBitMask(
+        std::static_pointer_cast<Control::element_type>(_ctrl)->badMaskPlanes
+    );
 }
 
 }}}} // namespace lsst::meas::extensions::shapeHSM

--- a/src/HsmMoments.cc
+++ b/src/HsmMoments.cc
@@ -53,8 +53,8 @@ base::FlagDefinitionList const & HsmMomentsAlgorithm::getFlagDefinitions() {
 template<typename PixelT>
 void HsmMomentsAlgorithm::calculate(
     afw::table::SourceRecord& source,
-    PTR(afw::image::Image<PixelT>) const& afwImage,
-    PTR(afw::image::Mask<afw::image::MaskPixel>) const& afwMask,
+    std::shared_ptr<afw::image::Image<PixelT>> const& afwImage,
+    std::shared_ptr<afw::image::Mask<afw::image::MaskPixel>> const& afwMask,
     geom::Box2I const& bbox,
     geom::Point2D const& center,
     afw::image::MaskPixel const badPixelMask,
@@ -63,7 +63,7 @@ void HsmMomentsAlgorithm::calculate(
     bool addFlux
 ) const {
     ImageConverter<PixelT> const image(afwImage, bbox);
-    PTR(afw::image::Image<int>) hsmMask = convertMask(*afwMask, bbox, badPixelMask);
+    std::shared_ptr<afw::image::Image<int>> hsmMask = convertMask(*afwMask, bbox, badPixelMask);
     ImageConverter<int> const mask(hsmMask, bbox);
 
     galsim::hsm::ShapeData shape;
@@ -145,10 +145,10 @@ void HsmPsfMomentsAlgorithm::measure(
     geom::Point2D center = _centroidExtractor(source, _flagHandler);
 
     typedef afw::image::Mask<afw::image::MaskPixel> Mask;
-    PTR(afw::detection::Psf::Image) image = exposure.getPsf()->computeKernelImage(center);
+    std::shared_ptr<afw::detection::Psf::Image> image = exposure.getPsf()->computeKernelImage(center);
 
     // Create a dummy mask
-    PTR(Mask) mask = std::make_shared<Mask>(image->getDimensions());
+    std::shared_ptr<Mask> mask = std::make_shared<Mask>(image->getDimensions());
     *mask = 0;
     mask->setXY0(image->getXY0());
 

--- a/src/HsmShape.cc
+++ b/src/HsmShape.cc
@@ -163,17 +163,17 @@ void HsmShapeAlgorithm::measure(
         );
     }
 
-    PTR(afw::detection::Psf::Image) psf = exposure.getPsf()->computeImage(center);
+    std::shared_ptr<afw::detection::Psf::Image> psf = exposure.getPsf()->computeImage(center);
     psf->setXY0(0, 0);
     ImageConverter<float> const image(exposure.getMaskedImage().getImage(), bbox);
     ImageConverter<afw::detection::Psf::Image::Pixel> const psfImage(psf);
 
     typedef afw::image::Image<int> ImageI;
-    PTR(afw::image::Exposure<float>::MaskedImageT::Mask) afwMask = exposure.getMaskedImage().getMask();
-    PTR(ImageI) hsmMask = convertMask(*afwMask, bbox, badPixelMask);
+    std::shared_ptr<afw::image::Exposure<float>::MaskedImageT::Mask> afwMask = exposure.getMaskedImage().getMask();
+    std::shared_ptr<ImageI> hsmMask = convertMask(*afwMask, bbox, badPixelMask);
     ImageConverter<int> const mask(hsmMask, bbox);
 
-    PTR(ImageI) dummyMask = std::make_shared<ImageI>(psf->getDimensions());
+    std::shared_ptr<ImageI> dummyMask = std::make_shared<ImageI>(psf->getDimensions());
     *dummyMask = 1;
     ImageConverter<int> const psfMask(dummyMask);
 


### PR DESCRIPTION
Debiased PSF moments are computed by rescaling flux and adding noise to
the PSF image before measuring normally.