### PR TITLE
DM-12659: Fix C++ import of pure-Python package

### DIFF
--- a/ups/meas_extensions_shapeHSM.cfg
+++ b/ups/meas_extensions_shapeHSM.cfg
@@ -3,7 +3,7 @@
 import lsst.sconsUtils
 
 dependencies = {
-    "required": ["utils", "afw", "meas_base", "meas_algorithms", "galsim"],
+    "required": ["cpputils", "afw", "meas_base", "meas_algorithms", "galsim"],
     "buildRequired": ["pybind11"],
 }
 


### PR DESCRIPTION
This PR stops C++ imports of `utils`, which as a pure-Python package no longer supports such imports. It's `cpputils` that could produce headers and libraries.