### PR TITLE
DM-41994-v24: Speed up galsim interface with meas_extensions_shapeHSM

### DIFF
--- a/python/lsst/meas/extensions/shapeHSM/_hsm_moments.py
+++ b/python/lsst/meas/extensions/shapeHSM/_hsm_moments.py
@@ -261,7 +261,7 @@ class HsmSourceMomentsPlugin(HsmMomentsPlugin):
         # Turn bounding box corners into GalSim bounds.
         xmin, xmax = bbox.getMinX(), bbox.getMaxX()
         ymin, ymax = bbox.getMinY(), bbox.getMaxY()
-        bounds = galsim.bounds.BoundsI(xmin, xmax, ymin, ymax)
+        bounds = galsim._BoundsI(xmin, xmax, ymin, ymax)
 
         # Get the `lsst.meas.base` mask for bad pixels.
         badpix = exposure.mask[bbox].array.copy()
@@ -418,7 +418,7 @@ class HsmPsfMomentsPlugin(HsmMomentsPlugin):
         # Turn bounding box corners into GalSim bounds.
         xmin, xmax = bbox.getMinX(), bbox.getMaxX()
         ymin, ymax = bbox.getMinY(), bbox.getMaxY()
-        bounds = galsim.bounds.BoundsI(xmin, xmax, ymin, ymax)
+        bounds = galsim._BoundsI(xmin, xmax, ymin, ymax)
 
         # Adjust the psfImage for noise as needed, and retrieve the mask of bad
         # pixels.


### PR DESCRIPTION
Accumulated PR including v24 backported tickets for review:
[DM-30947](https://jira.lsstcorp.org/browse/DM-30947?src=confmacro)
[DM-41489](https://jira.lsstcorp.org/browse/DM-41489?src=confmacro)
[DM-41994](https://jira.lsstcorp.org/browse/DM-41994?src=confmacro)
[DM-41908](https://jira.lsstcorp.org/browse/DM-41908?src=confmacro)

Individual PR will be merged in this order to preserve the backport history